### PR TITLE
Duplicate nested element

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,12 @@ group :development do
   gem "bundler", "~> 1.1.3"
   gem "jeweler", "~> 1.8.4"
   gem "simplecov"
+  #gem "debugger"
   #gem "rcov", ">= 0"
+
+  gem "guard"
+  gem "guard-rspec"
+  gem "rb-inotify", :require => false
+  gem "rb-fsevent", :require => false
+  gem "rb-fchange", :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.3.2)
+    coderay (1.0.8)
     cookiejar (0.3.0)
     diff-lcs (1.1.3)
     em-http-request (1.0.2)
@@ -13,7 +14,16 @@ GEM
     em-socksify (0.2.0)
       eventmachine (>= 1.0.0.beta.4)
     eventmachine (1.0.0.rc.4)
+    ffi (1.1.5)
     git (1.2.5)
+    guard (1.5.4)
+      listen (>= 0.4.2)
+      lumberjack (>= 1.0.2)
+      pry (>= 0.9.10)
+      thor (>= 0.14.6)
+    guard-rspec (2.3.0)
+      guard (>= 1.1)
+      rspec (~> 2.11)
     http_parser.rb (0.5.3)
     jeweler (1.8.4)
       bundler (~> 1.0)
@@ -21,9 +31,21 @@ GEM
       rake
       rdoc
     json (1.7.4)
+    listen (0.6.0)
+    lumberjack (1.0.2)
+    method_source (0.8.1)
     multi_json (1.3.6)
     nokogiri (1.5.5)
+    pry (0.9.10)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.3.1)
     rake (0.9.2.2)
+    rb-fchange (0.0.6)
+      ffi
+    rb-fsevent (0.9.2)
+    rb-inotify (0.8.8)
+      ffi (>= 0.5.0)
     rdoc (3.12)
       json (~> 1.4)
     rspec (2.11.0)
@@ -38,6 +60,8 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
+    slop (3.3.3)
+    thor (0.16.0)
 
 PLATFORMS
   ruby
@@ -46,7 +70,12 @@ DEPENDENCIES
   bundler (~> 1.1.3)
   em-http-request (>= 1.0.2)
   eventmachine (= 1.0.0.rc.4)
+  guard
+  guard-rspec
   jeweler (~> 1.8.4)
   nokogiri (>= 1.5.5)
+  rb-fchange
+  rb-fsevent
+  rb-inotify
   rspec (~> 2.11.0)
   simplecov

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,9 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard 'rspec' do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+end
+

--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ end
 
 task :default => :spec
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/lib/bliss/constraint.rb
+++ b/lib/bliss/constraint.rb
@@ -39,8 +39,8 @@ module Bliss
                 @state = :passed
               else
                 if @setting == :tag_name_required
-                  puts "hash: #{hash.inspect}"
-                  puts "self.tag_names: #{self.tag_names.inspect}"
+                  #puts "hash: #{hash.inspect}"
+                  #puts "self.tag_names: #{self.tag_names.inspect}"
                   @state = :not_passed
                 end
               end

--- a/lib/bliss/parser.rb
+++ b/lib/bliss/parser.rb
@@ -82,6 +82,10 @@ module Bliss
       @on_timeout = block
     end
 
+    def on_finished(&block)
+      @on_finished = block
+    end
+
     def wait_tag_close(element)
       @wait_tag_close = "</#{element}>"
     end
@@ -240,11 +244,10 @@ module Bliss
           end
           parser.secure_close
         }
-        http.callback {
-          #if @file
-          #  @file.close
-          #end
-          #EM.stop
+        http.callback {|http|
+          if @on_finished
+            @on_finished.call
+          end
           parser.secure_close
         }
       end

--- a/lib/bliss/parser.rb
+++ b/lib/bliss/parser.rb
@@ -246,7 +246,7 @@ module Bliss
         }
         http.callback {|http|
           if @on_finished
-            @on_finished.call
+            @on_finished.call(http)
           end
           parser.secure_close
         }

--- a/lib/bliss/parser_machine.rb
+++ b/lib/bliss/parser_machine.rb
@@ -57,7 +57,7 @@ module Bliss
       return if is_closed?
       # element_transformation
 			
-			@depth.push(element) if @depth.last != element
+			@depth.push(element)
       
       # TODO search on hash with xpath style
       # for example:

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -140,7 +140,7 @@ describe Bliss::Parser do
       @parser.on_tag_close("ads/ad") { |hash, depth|
         hash['foo'].should == "bar"
         hash['property_type'].should == "Terreno ó Lote"
-        puts hash
+        #puts hash
       }
       @parser.parse
 
@@ -164,7 +164,7 @@ describe Bliss::Parser do
       @parser = Bliss::Parser.new("mock", "test.xml")
 
       @parser.on_tag_close("root/item") { |hash, depth|
-        puts hash.inspect
+        #puts hash.inspect
         hash.should have_key("element")
         hash["element"].attrs.should be_a Hash
         hash["element"].attrs["attribute1"].should == "bla"

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -31,17 +31,17 @@ describe Bliss::Parser do
     end
 
 		it "should read nested elements" do
-			xml = <<-EOF
-<root>
-	<item>
-		<container>
-			<nested>1</nested>
-			<nested>2</nested>
-			<nested>3</nested>
-		</container>
-	</item>
-</root>
-EOF
+			xml = <<-XML
+        <root>
+          <item>
+            <container>
+              <nested>1</nested>
+              <nested>2</nested>
+              <nested>3</nested>
+            </container>
+          </item>
+        </root>
+      XML
 
       mocked_request(xml)
       
@@ -62,24 +62,24 @@ EOF
 		end
 		
 		it "should read containers of nested elements" do
-			xml = <<-EOF
-<root>
-	<item>
-		<container>
-			<nested>1</nested>
-			<nested>2</nested>
-			<nested>3</nested>
-		</container>
-	</item>
-	<item>
-		<id>a</id>
-		<container>
-			<nested>4</nested>
-			<nested>5</nested>
-		</container>
-	</item>
-</root>
-EOF
+			xml = <<-XML
+        <root>
+          <item>
+            <container>
+              <nested>1</nested>
+              <nested>2</nested>
+              <nested>3</nested>
+            </container>
+          </item>
+          <item>
+            <id>a</id>
+            <container>
+              <nested>4</nested>
+              <nested>5</nested>
+            </container>
+          </item>
+        </root>
+      XML
 
       mocked_request(xml)
       
@@ -123,14 +123,16 @@ EOF
     end
 
     it "should not eat spaces" do
-      mocked_request('
-<ads>
-  <ad>
-    <property_type>Terreno ó Lote</property_type>
-    <foo>bar</foo>
-  </ad>
-</ads>
-')
+      xml = <<-XML
+        <ads>
+          <ad>
+            <property_type>Terreno ó Lote</property_type>
+            <foo>bar</foo>
+          </ad>
+        </ads>
+      XML
+
+      mocked_request(xml)
       
       @parser = Bliss::Parser.new('mock')
 
@@ -147,15 +149,15 @@ EOF
 
   context "parsing XML attributes" do
     it "should parse them right" do
-      xml = <<-EOF
-<root>
-  <item>
-    <element attribute1="bla" attribute2="blo">
-      1
-    </element>
-  </item>
-</root>
-EOF
+      xml = <<-XML
+        <root>
+          <item>
+            <element attribute1="bla" attribute2="blo">
+              1
+            </element>
+          </item>
+        </root>
+      XML
 
       mocked_request(xml)
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -175,6 +175,36 @@ describe Bliss::Parser do
     end
   end
 
+  context "when XML has an element nested in another with the same name" do
+    it "should parse them right" do
+      xml = <<-XML
+        <root>
+          <item>
+            <element>
+              <element>1</element>
+              <element>2</element>
+            </element>
+          </item>
+        </root>
+      XML
+      mocked_request(xml)
+
+      @parser = Bliss::Parser.new("mock")
+
+      @parser.on_tag_close("root/item") do |hash, depth|
+        #puts "**** #{hash} ****"
+        hash.should have_key("element")
+        hash["element"].should be_a Hash
+        hash["element"].should have_key("element")
+        hash["element"]["element"].should be_a Array
+        hash["element"]["element"].size.should be_equal 2
+        hash["element"]["element"].should == ["1", "2"]
+      end
+
+      @parser.parse
+    end
+  end
+
   context 'when parsing a document with encoding issues' do
     it "should raise the on_error callback and continue parsing" do
       xml = File.read(File.dirname(File.expand_path(__FILE__)) + "/mock/encoding.xml")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ def mocked_request(content, opts={})
   http_client.stub(:headers).and_yield {}
   http_client.stub(:stream).and_yield(content) { }
   http_client.stub(:errback).and_yield {}
-  http_client.stub(:callback).and_yield {}
+  http_client.stub(:callback)
   
   http_connection = mock(EM::HttpConnection)
   http_connection.stub(:get) { http_client }


### PR DESCRIPTION
When you have an element inside another with the same name, it broke :)

``` xml
<root>
  <feature>
    <feature>1</feature>
    <feature>2</feature>
  </feature>
</root>
```

Ends up returning this hash:

``` ruby
{
  "root" => {
    "feature" => [{}, 1, 2]
  }
}
```

I [removed an `if`](https://github.com/sumavisos/bliss/commit/cae8effa0bb166504d55814fab470c6dc4159f0a) that seems to ignore this case, though I'm not 100% sure this breaks something. But this spec passes, and the other specs are also good.
